### PR TITLE
Change OG title and description when displaying a relationship

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,8 @@
     gtag('config', 'G-2N81WZX8SV');
   </script>
   <title>Royal Relationships</title>
+  <meta property="og:title" content="Royal Relationships">
+  <meta property="og:description" content="Discover the relationships between British monarchs">
 
   <link rel="shortcut icon" href="https://lineofsuccession.co.uk/favicon.ico" type="image/x-icon">
   <link href="https://fonts.googleapis.com/css?family=Faustina" rel="stylesheet">

--- a/docs/rels.js
+++ b/docs/rels.js
@@ -1,3 +1,15 @@
+function updateOGTags(title, description) {
+  var ogTitle = document.querySelector('meta[property="og:title"]');
+  var ogDescription = document.querySelector('meta[property="og:description"]');
+
+  if (ogTitle) {
+    ogTitle.setAttribute('content', title);
+  }
+
+  if (ogDescription) {
+    ogDescription.setAttribute('content', description);
+  }
+}
 
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', function() {
@@ -92,6 +104,11 @@ function handleDropdownChange() {
     var relationshipDiv = document.getElementById('relationship');
     relationshipDiv.innerHTML = monarch1.name + ' is ' + rel1 + ' of ' + monarch2.name + '<br>'
                               + monarch2.name + ' is ' + rel2 + ' of ' + monarch1.name;
+
+    // Update OG tags
+    var ogTitle = monarch1.name + ' and ' + monarch2.name + ' Relationship';
+    var ogDescription = 'Discover the relationship between ' + monarch1.name + ' and ' + monarch2.name;
+    updateOGTags(ogTitle, ogDescription);
 
     // Get the rels[monarch1][monarch2].ancestors
     var ancestors = rels[monarchId1][monarchId2].ancestors;


### PR DESCRIPTION
Related to #2

Add functionality to change OG title and description when displaying a relationship between monarchs.

* **docs/index.html**
  - Add OG title and description tags in the `<head>` section.
  - Set default OG title to "Royal Relationships".
  - Set default OG description to "Discover the relationships between British monarchs".

* **docs/rels.js**
  - Add a function `updateOGTags` to update OG title and description.
  - Call `updateOGTags` function to update OG title and description when a relationship is displayed.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/royalrels/issues/2?shareId=d7b74280-93de-4814-af6b-6cb027614bb5).